### PR TITLE
Add PHP gd extension as required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-ctype": "*",
+        "ext-gd": "*",
         "ext-iconv": "*",
         "composer/package-versions-deprecated": "^1.11",
         "intervention/image": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78e51eaae57689b60c175fe901cd214c",
+    "content-hash": "f0dfcc32a387698561f07d249800ff45",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -5557,6 +5557,7 @@
     "platform": {
         "php": "^7.1.3",
         "ext-ctype": "*",
+        "ext-gd": "*",
         "ext-iconv": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
GD extension is not in the standard pack of PHP modules, and it is required for running this project. 

Although is mandatory for vendor package, I think it should also be put here.

![Error missing GD library](https://i.ibb.co/9hY5Tbg/Screenshot-from-2021-04-28-11-26-40.png)

There is also one more case in the [comments](http://disq.us/p/2692hxk):